### PR TITLE
Call owner's renderer to keep view context.

### DIFF
--- a/protected/extensions/widgets/tabularinput/XTabularInput.php
+++ b/protected/extensions/widgets/tabularinput/XTabularInput.php
@@ -281,10 +281,10 @@ class XTabularInput extends CWidget
 	        $index=$_GET['index'];
     	    $owner=$this->getOwner();
 
-    		foreach($this->models as $index=>$model)
+    		foreach($this->models as $model)
     		{
     	        $params=array(
-    	        		'model'=>$this->models,
+    	        		'model'=>$model,
     	        		'index'=>$index++,
     	        );
     		    if($owner instanceof CWidget) {
@@ -359,7 +359,6 @@ SCRIPT;
 	 */
 	protected function renderContent()
 	{
-	    print "\n";
 	    $owner=$this->getOwner();
 		foreach($this->models as $index=>$model)
 		{

--- a/protected/extensions/widgets/tabularinput/XTabularInput.php
+++ b/protected/extensions/widgets/tabularinput/XTabularInput.php
@@ -221,12 +221,20 @@ class XTabularInput extends CWidget
 	 * Default CSS class for the element that adds inputs.
 	 */
 	public $addCssClass='tabular-input-add';
-
+	
+	public $modelName;
+	
+	public static function actions() {
+	    return array(
+	        'getinput'=>'XTabularInput',
+	    );
+	}
 	/**
 	 * Initializes the widget.
 	 */
 	public function init()
 	{
+	    $this->inputUrl=Yii::app()->getController()->createUrl($this->actionPrefix."getinput");
 		if(isset($this->containerHtmlOptions['id']))
 			$this->id=$this->containerHtmlOptions['id'];
 		else
@@ -266,17 +274,36 @@ class XTabularInput extends CWidget
 	/**
 	 * Renders the widget.
 	 */
-	public function run()
+	public function run($action=null)
 	{
-		$this->registerClientScript();
-		echo CHtml::openTag($this->containerTagName, $this->containerHtmlOptions);
-		if($this->header)
-			echo CHtml::tag($this->headerTagName, $this->headerHtmlOptions, $this->header);
-		echo CHtml::openTag($this->inputContainerTagName, $this->inputContainerHtmlOptions);
-		$this->renderContent();
-		echo CHtml::closeTag($this->inputContainerTagName);
-		echo $this->getAddLink();
-		echo CHtml::closeTag($this->containerTagName);
+	    if((Yii::app()->request->isAjaxRequest && isset($_GET['index'])))
+	    {
+	        $index=$_GET['index'];
+    	    $owner=$this->getOwner();
+
+    		foreach($this->models as $index=>$model)
+    		{
+    	        $params=array(
+    	        		'model'=>$this->models,
+    	        		'index'=>$index++,
+    	        );
+    		    if($owner instanceof CWidget) {
+    			    $owner->render($this->inputView, $params);
+    			} else {
+    			    $owner->renderPartial($this->inputView, $params);
+    			}
+    		}
+	    } else {
+    		$this->registerClientScript();
+    		echo CHtml::openTag($this->containerTagName, $this->containerHtmlOptions);
+    		if($this->header)
+    			echo CHtml::tag($this->headerTagName, $this->headerHtmlOptions, $this->header);
+    		echo CHtml::openTag($this->inputContainerTagName, $this->inputContainerHtmlOptions);
+    		$this->renderContent();
+    		echo CHtml::closeTag($this->inputContainerTagName);
+    		echo $this->getAddLink();
+    		echo CHtml::closeTag($this->containerTagName);
+	    }
 	}
 
 	/**
@@ -332,20 +359,20 @@ SCRIPT;
 	 */
 	protected function renderContent()
 	{
+	    print "\n";
 	    $owner=$this->getOwner();
 		foreach($this->models as $index=>$model)
 		{
 			echo CHtml::openTag($this->inputTagName, $this->inputHtmlOptions);
 			if($owner instanceof CWidget) {
-			    $this->getOwner()->render($this->inputView, array('model'=>$model, 'index'=>$index));
+			    $owner->render($this->inputView, array('model'=>$model, 'index'=>$index));
 			} else {
-			    $this->getOwner()->renderPartial($this->inputView, array('model'=>$model, 'index'=>$index));
+			    $owner->renderPartial($this->inputView, array('model'=>$model, 'index'=>$index));
 			}
 			echo $this->getRemoveLinkAndIndexInput($index);
 			echo CHtml::closeTag($this->inputTagName);
 		}
 	}
-
 
 	/**
 	 * Get the the link that adds tabular input.

--- a/protected/extensions/widgets/tabularinput/XTabularInput.php
+++ b/protected/extensions/widgets/tabularinput/XTabularInput.php
@@ -332,14 +332,20 @@ SCRIPT;
 	 */
 	protected function renderContent()
 	{
+	    $owner=$this->getOwner();
 		foreach($this->models as $index=>$model)
 		{
 			echo CHtml::openTag($this->inputTagName, $this->inputHtmlOptions);
-			$this->controller->renderPartial($this->inputView, array('model'=>$model, 'index'=>$index));
+			if($owner instanceof CWidget) {
+			    $this->getOwner()->render($this->inputView, array('model'=>$model, 'index'=>$index));
+			} else {
+			    $this->getOwner()->renderPartial($this->inputView, array('model'=>$model, 'index'=>$index));
+			}
 			echo $this->getRemoveLinkAndIndexInput($index);
 			echo CHtml::closeTag($this->inputTagName);
 		}
 	}
+
 
 	/**
 	 * Get the the link that adds tabular input.


### PR DESCRIPTION
This modification ensures that the inputView will be rendered as known in the owner's context.
If the context was the CController it was ok, but when using XTabularInput from a CWidget, it was not.
